### PR TITLE
Fix Facebook login error

### DIFF
--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -25,7 +25,7 @@ var provider = {
     FB.login((response) => {
       if (response.authResponse) {
         if (options.success) {
-          options.success(self, {
+          options.success(this, {
             id: response.authResponse.userID,
             access_token: response.authResponse.accessToken,
             expiration_date: new Date(response.authResponse.expiresIn * 1000 +


### PR DESCRIPTION
There was a javascript error that caused FacebookUtils.authenticate to crash and made login with Facebook impossible since v1.6.0.

Fixes https://developers.facebook.com/bugs/882121675197813/