### PR TITLE
Avoid recursion on encoding circular pointers

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -373,7 +373,7 @@ export default class ParseObject {
       if ((attr === 'createdAt' || attr === 'updatedAt') && attrs[attr].toJSON) {
         json[attr] = attrs[attr].toJSON();
       } else {
-        json[attr] = encode(attrs[attr], false, false);
+        json[attr] = encode(attrs[attr], false, true);
       }
     }
     var pending = this._getPendingOps();

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -523,6 +523,47 @@ describe('ParseObject', () => {
     expect(o2.get('age')).toBe(22);
   });
 
+  it('does not stack-overflow when encoding recursive pointers', () => {
+    var o = ParseObject.fromJSON({
+      __type: 'Object',
+      className: 'Item',
+      objectId: 'recurParent',
+      child: {
+        __type: 'Pointer',
+        className: 'Item',
+        objectId: 'recurChild'
+      }
+    });
+    expect(o.toJSON()).toEqual({
+      objectId: 'recurParent',
+      child: {
+        __type: 'Pointer',
+        className: 'Item',
+        objectId: 'recurChild'
+      }
+    });
+
+    var child = ParseObject.fromJSON({
+      __type: 'Object',
+      className: 'Item',
+      objectId: 'recurChild',
+      parent: {
+        __type: 'Pointer',
+        className: 'Item',
+        objectId: 'recurParent'
+      }
+    });
+
+    expect(o.toJSON()).toEqual({
+      objectId: 'recurParent',
+      child: {
+        __type: 'Pointer',
+        className: 'Item',
+        objectId: 'recurChild'
+      }
+    });
+  });
+
   it('updates the existed flag when saved', () => {
     var o = new ParseObject('Item');
     expect(o.existed()).toBe(false);


### PR DESCRIPTION
objects should only be encoded with flat pointers, not inflated objects. This adds a test that fails without this change.