### PR TITLE
Expose error in _linkWith recursive call

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -108,6 +108,8 @@ export default class ParseUser extends ParseObject {
           }
           this._linkWith(provider, opts).then(() => {
             promise.resolve(this);
+          }, (error) => {
+            promise.reject(error);
           });
         },
         error: (provider, error) => {

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -32,6 +32,7 @@ var ParseObject = require('../ParseObject');
 var ParsePromise = require('../ParsePromise');
 var ParseUser = require('../ParseUser');
 var Storage = require('../Storage');
+var ParseError = require('../ParseError');
 
 var asyncHelper = require('./test_helpers/asyncHelper');
 
@@ -357,6 +358,51 @@ describe('ParseUser', () => {
       expect(u.getUsername()).toBe('bob');
       expect(u.id).toBe('abc');
       expect(u.getSessionToken()).toBe('12345');
+      done();
+    });
+  }));
+
+  it('can get error when recursive _linkWith call fails', asyncHelper((done) => {
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('POST');
+        expect(path).toBe('users');
+        expect(body.authData.test).toEqual({
+          id : 'id',
+          access_token : 'access_token'
+        });
+        var error = new ParseError(
+          ParseError.ACCOUNT_ALREADY_LINKED,
+          'Another user is already linked to this facebook id.'
+        );
+        return ParsePromise.error(error);
+      },
+      ajax() {}
+    });
+    var provider = {
+      authenticate(options) {
+        if (options.success) {
+          options.success(this, {
+            id: 'id',
+            access_token: 'access_token'
+          });
+        }
+      },
+
+      restoreAuthentication(authData) {},
+
+      getAuthType() {
+        return 'test';
+      },
+
+      deauthenticate() {}
+    };
+    
+    ParseUser.logInWith(provider, {}).then(() => {
+
+    }, (error) => {
+      expect(error.code).toBe(ParseError.ACCOUNT_ALREADY_LINKED);
+      expect(error.message).toBe('Another user is already linked to this facebook id.');
       done();
     });
   }));

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -397,10 +397,8 @@ describe('ParseUser', () => {
 
       deauthenticate() {}
     };
-    
-    ParseUser.logInWith(provider, {}).then(() => {
 
-    }, (error) => {
+    ParseUser.logInWith(provider, {}).then(null, (error) => {
       expect(error.code).toBe(ParseError.ACCOUNT_ALREADY_LINKED);
       expect(error.message).toBe('Another user is already linked to this facebook id.');
       done();


### PR DESCRIPTION
When `_linkWith` is called recursively, we can not get the error thrown by the not first `_linkWith` call, as mentioned in #12 . This PR fixes this and add a test.