### PR TITLE
Strip anonymous when we set username

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -277,6 +277,13 @@ export default class ParseUser extends ParseObject {
    * @return {Boolean}
    */
   setUsername(username: string) {
+    // Strip anonymity, even we do not support anonymous user in js SDK, we may
+    // encounter anonymous user created by android/iOS in cloud code.
+    var authData = this.get('authData');
+    if (authData && authData.hasOwnProperty('anonymous')) {
+      // We need to set anonymous to null instead of deleting it in order to remove it from Parse.
+      authData.anonymous = null;
+    }
     this.set('username', username);
   }
 

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -401,4 +401,20 @@ describe('ParseUser', () => {
       done();
     });
   }));
+
+  it('strip anonymity when we set username', () => {
+    var user = new ParseUser();
+    var authData = {
+      anonymous : {
+        id : 'anonymousId'
+      }
+    }
+    user.set('authData', authData);
+    expect(user.get('authData').anonymous.id).toBe('anonymousId');
+
+    // Set username should strip anonymous authData
+    user.setUsername('test');
+    expect(user.getUsername()).toBe('test');
+    expect(user.get('authData').anonymous).toBe(null);
+  });
 });


### PR DESCRIPTION
Strip anonymous when we set username, even we do not support anonymous user in JS SDK, we may encounter anonymous users created by android/iOS in cloud code, so we need to do this.
Fix issue #13 