### PR TITLE
Make FacebookUtils work with React Native

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -694,10 +694,11 @@ export default class ParseUser extends ParseObject {
   static _registerAuthenticationProvider(provider) {
     authProviders[provider.getAuthType()] = provider;
     // Synchronize the current user with the auth provider.
-    var current = ParseUser.current();
-    if (current) {
-      current._synchronizeAuthData(provider.getAuthType());
-    }
+    ParseUser.currentAsync().then((current) => {
+      if (current) {
+        current._synchronizeAuthData(provider.getAuthType());
+      }
+    });
   }
 
   static _logInWith(provider, options) {


### PR DESCRIPTION
When calling `Parse.FacebookUtils.init();` from React Native I get this error (Parse v1.6.9)

![screen shot 2015-11-13 at 12 11 42 pm](https://cloud.githubusercontent.com/assets/192222/11156327/0ea5396a-8a00-11e5-8867-28092a60c38f.png)

This pull request fixes it. Not sure how to test if this breaks web behavior in any way.