### PR TITLE
Using proper undefined & null guard

### DIFF
--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -156,7 +156,7 @@ export default class ParsePromise {
       fn.call();
     };
     if (isPromisesAPlusCompliant) {
-      if (typeof process !== 'undefined' &&
+      if (process != null &&
           typeof process.nextTick === 'function') {
         runLater = function(fn) {
           process.nextTick(fn);
@@ -283,7 +283,7 @@ export default class ParsePromise {
    */
   static is(promise) {
     return (
-      typeof promise !== 'undefined' &&
+      typeof promise != null &&
       typeof promise.then === 'function'
     );
   }


### PR DESCRIPTION
`== null` / `!= null` is idiomatic and fast way to check for both `null` and `undefined`.
This is the guard that should be used prior to accessing a property of an object.
Otherwise, this blows when the object is `null`.

If accepted, pls release asap. Thanx.