### PR TITLE
Revert "Make sure `when` argument corresponds with `then` arguments"

### DIFF
--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -346,8 +346,7 @@ export default class ParsePromise {
    */
   static when(promises) {
     var objects;
-    var arrayArgument = Array.isArray(promises);
-    if (arrayArgument) {
+    if (Array.isArray(promises)) {
       objects = promises;
     } else {
       objects = arguments;
@@ -356,13 +355,12 @@ export default class ParsePromise {
     var total = objects.length;
     var hadError = false;
     var results = [];
-    var returnValue = arrayArgument ? [results] : results;
     var errors = [];
     results.length = objects.length;
     errors.length = objects.length;
 
     if (total === 0) {
-      return ParsePromise.as.apply(this, returnValue);
+      return ParsePromise.as.apply(this, results);
     }
 
     var promise = new ParsePromise();
@@ -373,7 +371,7 @@ export default class ParsePromise {
         if (hadError) {
           promise.reject(errors);
         } else {
-          promise.resolve.apply(promise, returnValue);
+          promise.resolve.apply(promise, results);
         }
       }
     };

--- a/src/__tests__/ParsePromise-test.js
+++ b/src/__tests__/ParsePromise-test.js
@@ -227,7 +227,7 @@ describe('Promise', () => {
     jest.runAllTimers();
   }));
 
-  it('can handle promises in parallel with array', asyncHelper(function(done) {
+  it('can handle promises in parallel', asyncHelper(function(done) {
     var COUNT = 5;
 
     var delay = function(ms) {
@@ -249,42 +249,7 @@ describe('Promise', () => {
       generate(i);
     }
 
-    ParsePromise.when(promises).then(function(results) {
-      expect(called).toBe(COUNT);
-      expect(COUNT).toBe(results.length);
-      var actual = results;
-      for (var i = 0; i < actual.length; i++) {
-        expect(actual[i]).toBe(5 * i);
-      }
-      done();
-    });
-
-    jest.runAllTimers();
-  }));
-
-  it('can handle promises in parallel with arguments', asyncHelper(function(done) {
-    var COUNT = 5;
-
-    var delay = function(ms) {
-      var promise = new ParsePromise();
-      setTimeout(() => { promise.resolve(); }, ms);
-      return promise;
-    };
-
-    var called = 0;
-    var promises = [];
-    function generate(i) {
-      promises[i] = delay((i % 2) ? (i * 10) : (COUNT * 10) - (i * 10)).then(
-        function() {
-          called++;
-          return 5 * i;
-        });
-    }
-    for (var i = 0; i < COUNT; i++) {
-      generate(i);
-    }
-
-    ParsePromise.when.apply(null, promises).then(function() {
+    ParsePromise.when(promises).then(function() {
       expect(called).toBe(COUNT);
       expect(COUNT).toBe(arguments.length);
       var actual = arguments;


### PR DESCRIPTION
Reverts ParsePlatform/Parse-SDK-JS#115

Unfortunately, I did not realize that this introduced breaking changes