### PR TITLE
Handle ACL on save

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -334,6 +334,8 @@ export default class ParseObject {
       if ((attr === 'createdAt' || attr === 'updatedAt') &&
           typeof response[attr] === 'string') {
         changes[attr] = parseDate(response[attr]);
+      } else if (attr === 'ACL') {
+        changes[attr] = new ParseACL(response[attr]);
       } else if (attr !== 'objectId') {
         changes[attr] = decode(response[attr]);
       }

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -26,6 +26,7 @@ jest.dontMock('../RESTController');
 jest.dontMock('../TaskQueue');
 jest.dontMock('../unique');
 jest.dontMock('../unsavedChildren');
+jest.dontMock('../ParseACL');
 
 jest.dontMock('./test_helpers/asyncHelper');
 jest.dontMock('./test_helpers/mockXHR');
@@ -726,6 +727,18 @@ describe('ParseObject', () => {
       age: 24
     });
     expect(p.op('age')).toBe(undefined);
+  });
+
+  it('handles ACL when saved', () => {
+    var p = new ParseObject('Person');
+
+    p._handleSaveResponse({
+      ACL: {}
+    }, 201);
+
+    var acl = p.getACL();
+    expect(acl).not.toEqual(null);
+    expect(acl instanceof ParseACL).toBe(true);
   });
 
   it('replaces a local id with a real one when saved', () => {


### PR DESCRIPTION
It seems we do not handle ACL on save. Normally for a save/update, the server just return `createAt, objectId` and `updateAt`, so it is fine. However, if the developers enable beforeSave for this class, the server will return the full object. In this situation, if we do not handle ACL, it will make `object.getACL()` return `null`.
I follow the way we handle ACL in `_finishFetch` to handle ACL. Not sure it is the best way to do that.