### PR TITLE
Updated query result handling to fix querying for unfetched relations

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -277,7 +277,9 @@ export default class ParseQuery {
       findOptions
     ).then((response) => {
       return response.results.map((data) => {
-        data.className = this.className;
+        if (!data.className) {
+          data.className = this.className;
+        }
         return ParseObject.fromJSON(data);
       });
     })._thenRunCallbacks(options);
@@ -373,7 +375,9 @@ export default class ParseQuery {
       if (!objects[0]) {
         return undefined;
       }
-      objects[0].className = this.className;
+      if (!objects[0].className) {
+        objects[0].className = this.className;
+      }
       return ParseObject.fromJSON(objects[0]);
     })._thenRunCallbacks(options);
   }


### PR DESCRIPTION
In the case where you query a relation key on an unfetched object, you don't know the className of the objects you will receive.  The SDK uses the redirectClassNameForKey parameter in the query, and the correct className is provided by the server, but it is being ignored and overwritten by the SDK here.

```javascript
// Setup data model
var Wheel = Parse.Object.extend('Wheel');
var Car = Parse.Object.extend('Car');
var origWheel = new Wheel();
origWheel.save().then(function() {
  var car = new Car();
  var relation = car.relation('wheels');
  relation.add(origWheel);
  return car.save();
}).then(function(car) {
  // Create an un-fetched shell car object
  var unfetchedCar = new Car();
  unfetchedCar.id = car.id;
  var relation = unfetchedCar.relation('wheels');
  var query = relation.query();

  // Parent object is un-fetched, so this will call /1/classes/Car instead
  // of /1/classes/Wheel and pass { "redirectClassNameForKey":"wheels" }.
  return query.get(origWheel.id);
}).then(function(wheel) {
  // Make sure this is Wheel and not Car.
  strictEqual(wheel.className, 'Wheel');  // Fails here.
```

Not sure how to unit-test this as it only turned up in end-to-end work.. let me know what you think.