### PR TITLE
Allow ES6-style Promise construction

### DIFF
--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -26,11 +26,15 @@ var isPromisesAPlusCompliant = true;
  * @constructor
  */
 export default class ParsePromise {
-  constructor() {
+  constructor(closure) {
     this._resolved = false;
     this._rejected = false;
     this._resolvedCallbacks = [];
     this._rejectedCallbacks = [];
+
+    if (typeof closure === 'function') {
+      closure(this.resolve.bind(this), this.reject.bind(this));
+    }
   }
 
   /**

--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -26,14 +26,14 @@ var isPromisesAPlusCompliant = true;
  * @constructor
  */
 export default class ParsePromise {
-  constructor(closure) {
+  constructor(executor) {
     this._resolved = false;
     this._rejected = false;
     this._resolvedCallbacks = [];
     this._rejectedCallbacks = [];
 
-    if (typeof closure === 'function') {
-      closure(this.resolve.bind(this), this.reject.bind(this));
+    if (typeof executor === 'function') {
+      executor(this.resolve.bind(this), this.reject.bind(this));
     }
   }
 

--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -306,6 +306,26 @@ export default class ParsePromise {
   }
 
   /**
+   * Returns a new promise that is resolved with a given value.
+   * If that value is a thenable Promise (has a .then() prototype
+   * method), the new promise will be chained to the end of the
+   * value.
+   * @method resolve
+   * @param value The value to resolve the promise with
+   * @static
+   * @return {Parse.Promise} the new promise.
+   */
+  static resolve(value) {
+    return new ParsePromise((resolve, reject) => {
+      if (ParsePromise.is(value)) {
+        value.then(resolve, reject);
+      } else {
+        resolve(value);
+      }
+    });
+  }
+
+  /**
    * Returns a new promise that is rejected with a given error.
    * @method error
    * @param error The error to reject the promise with
@@ -316,6 +336,19 @@ export default class ParsePromise {
     var promise = new ParsePromise();
     promise.reject.apply(promise, errors);
     return promise;
+  }
+
+  /**
+   * Returns a new promise that is rejected with a given error.
+   * This is an alias for Parse.Promise.error, for compliance with
+   * the ES6 implementation.
+   * @method reject
+   * @param error The error to reject the promise with
+   * @static
+   * @return {Parse.Promise} the new promise.
+   */
+  static reject(...errors) {
+    return ParsePromise.error.apply(null, errors);
   }
 
   /**

--- a/src/__tests__/ParsePromise-test.js
+++ b/src/__tests__/ParsePromise-test.js
@@ -433,6 +433,8 @@ describe('Promise', () => {
   });
 
   it('can be constructed in ES6 style and resolved', asyncHelper((done) => {
+    expect(ParsePromise.length).toBe(1); // constructor arguments
+
     new ParsePromise((resolve, reject) => {
       resolve('abc');
     }).then((result) => {
@@ -460,6 +462,24 @@ describe('Promise', () => {
       });
     }).then(null, (error) => {
       expect(error).toBe('err2');
+      done();
+    });
+  }));
+
+  it('can be initially resolved, ES6 style', asyncHelper((done) => {
+    ParsePromise.resolve('abc').then((result) => {
+      expect(result).toBe('abc');
+      
+      return ParsePromise.resolve(ParsePromise.as('def'));
+    }).then((result) => {
+      expect(result).toBe('def');
+      done();
+    });
+  }));
+
+  it('can be initially rejected, ES6 style', asyncHelper((done) => {
+    ParsePromise.reject('err').then(null, (error) => {
+      expect(error).toBe('err');
       done();
     });
   }));

--- a/src/__tests__/ParsePromise-test.js
+++ b/src/__tests__/ParsePromise-test.js
@@ -430,5 +430,37 @@ describe('Promise', () => {
     expect(ParsePromise.is({})).toBe(false);
     expect(ParsePromise.is(ParsePromise.as())).toBe(true);
     expect(ParsePromise.is(ParsePromise.error())).toBe(true);
-  })
+  });
+
+  it('can be constructed in ES6 style and resolved', asyncHelper((done) => {
+    new ParsePromise((resolve, reject) => {
+      resolve('abc');
+    }).then((result) => {
+      expect(result).toBe('abc');
+      
+      return new ParsePromise((resolve, reject) => {
+        resolve('def');
+      });
+    }).then((result) => {
+      expect(result).toBe('def');
+      done();
+    });
+  }));
+
+  it('can be constructed in ES6 style and rejected', asyncHelper((done) => {
+    new ParsePromise((resolve, reject) => {
+      reject('err');
+    }).then(() => {
+      // Should not be reached
+    }, (error) => {
+      expect(error).toBe('err');
+      
+      return new ParsePromise((resolve, reject) => {
+        reject('err2');
+      });
+    }).then(null, (error) => {
+      expect(error).toBe('err2');
+      done();
+    });
+  }));
 });


### PR DESCRIPTION
Allows Parse.Promises to be constructed in the ES6 "executor" style, without intervening with old construction.

```js
// Valid:
return new Parse.Promise((resolve, reject) => {
  myAsyncFunction((result) => {
    resolve(result);
  });
});

// Also still valid:
let p = new Parse.Promise();
myAsyncFunction((result) => {
  p.resolve(result);
});
return p;
```

cc @grantland 