### PR TITLE
Make sure the className is correct for results on unknown relations

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -261,7 +261,7 @@ export default class ParseQuery {
   find(options?: FullOptions): ParsePromise {
     options = options || {};
 
-    var findOptions = {};
+    let findOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -269,7 +269,7 @@ export default class ParseQuery {
       findOptions.sessionToken = options.sessionToken;
     }
 
-    var controller = CoreManager.getQueryController();
+    let controller = CoreManager.getQueryController();
 
     return controller.find(
       this.className,
@@ -277,8 +277,11 @@ export default class ParseQuery {
       findOptions
     ).then((response) => {
       return response.results.map((data) => {
+        // In cases of relations, the server may send back a className
+        // on the top level of the payload
+        let override = response.className || this.className;
         if (!data.className) {
-          data.className = this.className;
+          data.className = override;
         }
         return ParseObject.fromJSON(data);
       });

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1298,4 +1298,41 @@ describe('ParseQuery', () => {
     q = new ParseQuery('User');
     expect(q.className).toBe('User');
   });
+
+  it('does not override the className if it comes from the server', asyncHelper((done) => {
+    CoreManager.setQueryController({
+      find(className, params, options) {
+        return ParsePromise.as({
+          results: [
+            { className: 'Product', objectId: 'P40', name: 'Product 40' },
+          ]
+        });
+      }
+    });
+
+    var q = new ParseQuery('Item');
+    q.find().then((results) => {
+      expect(results[0].className).toBe('Product');
+      done();
+    });
+  }));
+
+  it('can override the className with a name from the server', asyncHelper((done) => {
+    CoreManager.setQueryController({
+      find(className, params, options) {
+        return ParsePromise.as({
+          results: [
+            { objectId: 'P41', name: 'Product 41' },
+          ],
+          className: 'Product'
+        });
+      }
+    });
+
+    var q = new ParseQuery('Item');
+    q.find().then((results) => {
+      expect(results[0].className).toBe('Product');
+      done();
+    });
+  }));
 });


### PR DESCRIPTION
If the target className of a relation is not known ahead of time, and the server does not pass the className back on the raw JSON of Parse Object results, the query results end up with the wrong className.
The className to be used comes back as a top-level key on the query result payload. This diff makes sure that value is used, if available.