### PR TITLE
Implement Promise.catch, Promise.all, Promise.race

### DIFF
--- a/src/__tests__/ParsePromise-test.js
+++ b/src/__tests__/ParsePromise-test.js
@@ -309,6 +309,27 @@ function promiseTests() {
     jest.runAllTimers();
   }));
 
+  it('immediately resolves when processing an empty array in parallel', asyncHelper((done) => {
+    ParsePromise.when([]).then((result) => {
+      expect(result).toEqual([]);
+      done();
+    });
+  }));
+
+  it('can handle rejected promises in parallel', asyncHelper((done) => {
+    ParsePromise.when([ParsePromise.as(1), ParsePromise.error('an error')]).then(null, (errors) => {
+      expect(errors).toEqual([undefined, 'an error']);
+      done();
+    });
+  }));
+
+  it('can automatically resolve non-promises in parallel', asyncHelper((done) => {
+    ParsePromise.when([1,2,3]).then((results) => {
+      expect(results).toEqual([1,2,3]);
+      done();
+    });
+  }));
+
   it('passes on errors', () => {
     ParsePromise.error('foo').then(() => {
       // This should not be reached
@@ -658,6 +679,20 @@ function promiseTests() {
     ).then(() => {
       expect(count).toBe(5);
       done();
+    });
+  }));
+
+  it('can attach a universal callback to a promise', asyncHelper((done) => {
+    ParsePromise.as(15)._continueWith((result, err) => {
+      expect(result).toEqual([15]);
+      expect(err).toBe(null);
+
+      ParsePromise.error('an error')._continueWith((result, err) => {
+        expect(result).toBe(null);
+        expect(err).toBe('an error');
+
+        done();
+      });
     });
   }));
 }

--- a/src/__tests__/ParsePromise-test.js
+++ b/src/__tests__/ParsePromise-test.js
@@ -14,6 +14,18 @@ var ParsePromise = require('../ParsePromise');
 var asyncHelper = require('./test_helpers/asyncHelper');
 
 describe('Promise', () => {
+  it('can disable A+ compliance', () => {
+    ParsePromise.disableAPlusCompliant();
+    expect(ParsePromise.isPromisesAPlusCompliant()).toBe(false);
+  });
+
+  it('can enable A+ compliance', () => {
+    ParsePromise.enableAPlusCompliant();
+    expect(ParsePromise.isPromisesAPlusCompliant()).toBe(true);
+  });
+});
+
+function promiseTests() {
   it('can be initially resolved', () => {
     var promise = ParsePromise.as('foo');
     promise.then((result) => {
@@ -428,6 +440,40 @@ describe('Promise', () => {
     });
   });
 
+  it('runs catch callbacks on error', () => {
+    var promise = ParsePromise.error('foo');
+    promise.fail((error) => {
+      expect(error).toBe('foo');
+    }).then((result) => {
+      if (ParsePromise.isPromisesAPlusCompliant()) {
+        expect(result).toBe(undefined);
+      } else {
+        // This should not be reached
+        expect(true).toBe(false);
+      }
+    }, (error) => {
+      if (ParsePromise.isPromisesAPlusCompliant()) {
+        // This should not be reached
+        expect(true).toBe(false);
+      } else {
+        expect(error).toBe(undefined);
+      }
+    });
+  });
+
+  it('does not run catch callbacks on success', () => {
+    var promise = ParsePromise.as('foo');
+    promise.catch((error) => {
+      // This should not be reached
+      expect(true).toBe(false);
+    }).then((result) => {
+      expect(result).toBe('foo');
+    }, (error) => {
+      // This should not be reached
+      expect(true).toBe(false);
+    });
+  });
+
   it('operates asynchonously', () => {
     var triggered = false;
     ParsePromise.as().then(() => {
@@ -518,4 +564,116 @@ describe('Promise', () => {
       done();
     });
   }));
+
+  it('resolves Promise.all with the set of resolved results', asyncHelper((done) => {
+    let firstSet = [
+      new ParsePromise(),
+      new ParsePromise(),
+      new ParsePromise(),
+      new ParsePromise()
+    ];
+
+    let secondSet = [5,6,7];
+
+    ParsePromise.all([]).then((results) => {
+      expect(results).toEqual([]);
+
+      return ParsePromise.all(firstSet);
+    }).then((results) => {
+      expect(results).toEqual([1,2,3,4]);
+      return ParsePromise.all(secondSet);
+    }).then((results) => {
+      expect(results).toEqual([5,6,7]);
+      done();
+    });
+    firstSet[0].resolve(1);
+    firstSet[1].resolve(2);
+    firstSet[2].resolve(3);
+    firstSet[3].resolve(4);
+  }));
+
+  it('rejects Promise.all with the first rejected promise', asyncHelper((done) => {
+    let promises = [
+      new ParsePromise(),
+      new ParsePromise(),
+      new ParsePromise()
+    ];
+
+    ParsePromise.all(promises).then(() => {
+      // this should not be reached
+    }, (error) => {
+      expect(error).toBe('an error');
+      done();
+    });
+    promises[0].resolve(1);
+    promises[1].reject('an error');
+    promises[2].resolve(3);
+  }));
+
+  it('resolves Promise.race with the first resolved result', asyncHelper((done) => {
+    let firstSet = [
+      new ParsePromise(),
+      new ParsePromise(),
+      new ParsePromise()
+    ];
+
+    let secondSet = [4, 5, ParsePromise.error()];
+
+    ParsePromise.race(firstSet).then((result) => {
+      expect(result).toBe(2);
+
+      return ParsePromise.race(secondSet);
+    }).then((result) => {
+      expect(result).toBe(4);
+      done();
+    });
+    firstSet[1].resolve(2);
+    firstSet[0].resolve(1);
+  }));
+
+  it('rejects Promise.race with the first rejected reason', asyncHelper((done) => {
+    let promises = [
+      new ParsePromise(),
+      new ParsePromise(),
+      new ParsePromise()
+    ];
+
+    ParsePromise.race(promises).fail((error) => {
+      expect(error).toBe('error 2');
+      done();
+    });
+    promises[1].reject('error 2');
+    promises[0].resolve('error 1');
+  }));
+
+  it('can implement continuations', asyncHelper((done) => {
+    let count = 0;
+    let loop = () => {
+      count++;
+      return ParsePromise.as();
+    }
+    ParsePromise._continueWhile(
+      () => { return count < 5 },
+      loop
+    ).then(() => {
+      expect(count).toBe(5);
+      done();
+    });
+  }));
+}
+
+describe('Promise (A Compliant)', () => {
+  beforeEach(() => {
+    ParsePromise.disableAPlusCompliant();
+  });
+
+  promiseTests();
+});
+
+describe('Promise (A+ Compliant)', () => {
+  beforeEach(() => {
+    ParsePromise.enableAPlusCompliant();
+  });
+
+  promiseTests();
 });


### PR DESCRIPTION
This adds the remaining APIs necessary to make Parse.Promise fully interchangeable with the ES6 Promise implementation.