### PR TITLE
Option to specify https for Parse.File url()

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -137,9 +137,12 @@ export default class ParseFile {
    * @param {Object} options An object to specify url options
    * @return {String}
    */
-  url(options?: { secure?: boolean }): ?string {
+  url(options?: { forceSecure?: boolean }): ?string {
     options = options || {};
-    if (options.secure) {
+    if (!this._url) {
+      return;
+    }
+    if (options.forceSecure) {
       return this._url.replace(/^http:\/\//i, 'https://');
     } else {
       return this._url;

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -134,10 +134,16 @@ export default class ParseFile {
    * Gets the url of the file. It is only available after you save the file or
    * after you get the file from a Parse.Object.
    * @method url
+   * @param {Object} options An object to specify url options
    * @return {String}
    */
-  url(): ?string {
-    return this._url;
+  url(options?: { secure?: boolean }): ?string {
+    options = options || {};
+    if (options.secure) {
+      return this._url.replace(/^http:\/\//i, 'https://');
+    } else {
+      return this._url;
+    }
   }
 
   /**

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -82,9 +82,14 @@ describe('ParseFile', () => {
     var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
     file.save().then(function(result) {
       expect(result).toBe(file);
-      expect(result.url({ secure: true }))
+      expect(result.url({ forceSecure: true }))
         .toBe('https://files.parsetfss.com/a/parse.txt');
     });
+  });
+
+  it('returns undefined when there is no url', () => {
+    var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
+    expect(file.url({ forceSecure: true })).toBeUndefined();
   });
 
   it('updates fields when saved', () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -78,6 +78,15 @@ describe('ParseFile', () => {
     }).toThrow('Cannot create a Parse.File with that data.');
   });
 
+  it('returns secure url when specified', () => {
+    var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
+    file.save().then(function(result) {
+      expect(result).toBe(file);
+      expect(result.url({ secure: true }))
+        .toBe('https://files.parsetfss.com/a/parse.txt');
+    });
+  });
+
   it('updates fields when saved', () => {
     var file = new ParseFile('parse.txt', { base64: 'ParseA==' });
     expect(file.name()).toBe('parse.txt');


### PR DESCRIPTION
This is a simple feature, and it would go a long way to have it implemented. Since files on `http://files.parsetfss.com` can also be accessed at `https://files.parsetfss.com`, I was surprised this isn't available yet. Been running into problems using `Parse.File` with images on a site using https, as it throws a Mixed Content warning. There may be a more consistent way to handle the api, but this works fine in my opinion.