### PR TITLE
Add the ability to pass an installationId in the backbone-style options on signup() and login().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 test_output
 *~
 .DS_Store
+.idea/

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -21,6 +21,7 @@ import type { PushData } from './Push';
 type RequestOptions = {
   useMasterKey?: boolean;
   sessionToken?: string;
+  installationId?: string;
 };
 type AnalyticsController = {
   track: (name: string, dimensions: { [key: string]: string }) => ParsePromise;

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -365,6 +365,9 @@ export default class ParseUser extends ParseObject {
     if (options.hasOwnProperty('useMasterKey')) {
       signupOptions.useMasterKey = options.useMasterKey;
     }
+    if (options.hasOwnProperty('installationId')) {
+      signupOptions.installationId = options.installationId;
+    }
 
     var controller = CoreManager.getUserController();
     return controller.signUp(
@@ -394,6 +397,9 @@ export default class ParseUser extends ParseObject {
     var loginOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       loginOptions.useMasterKey = options.useMasterKey;
+    }
+    if (options.hasOwnProperty('installationId')) {
+      loginOptions.installationId = options.installationId;
     }
 
     var controller = CoreManager.getUserController();

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -17,6 +17,7 @@ import Storage from './Storage';
 export type RequestOptions = {
   useMasterKey?: boolean;
   sessionToken?: string;
+  installationId?: string;
 };
 
 export type FullOptions = {
@@ -24,6 +25,7 @@ export type FullOptions = {
   error?: any;
   useMasterKey?: boolean;
   sessionToken?: string;
+  installationId?: string;
 };
 
 var XHR = null;
@@ -181,9 +183,16 @@ const RESTController = {
       payload._RevocableSession = '1';
     }
 
-    var installationController = CoreManager.getInstallationController();
+    var installationId = options.installationId;
+    var installationIdPromise;
+    if (installationId && typeof installationId === 'string') {
+      installationIdPromise = ParsePromise.as(installationId);
+    } else {
+      var installationController = CoreManager.getInstallationController();
+      installationIdPromise = installationController.currentInstallationId();
+    }
 
-    return installationController.currentInstallationId().then((iid) => {
+    return installationIdPromise.then((iid) => {
       payload._InstallationId = iid;
       var userController = CoreManager.getUserController();
       if (options && typeof options.sessionToken === 'string') {


### PR DESCRIPTION
I made it possible to pass along the _installationId_ (string) as property on the backbone-style options object. This is especially useful on the _login()_ and _signup()_ API when managing installations upfront.

If no _installationId_ is passed, the API acts as normal.