### PR TITLE
New API for creating a new instance of an object

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -775,7 +775,7 @@ export default class ParseObject {
   }
 
   /**
-   * Creates a new model with identical attributes to this one.
+   * Creates a new model with identical attributes to this one, similar to Backbone.Model's clone()
    * @method clone
    * @return {Parse.Object}
    */
@@ -800,6 +800,27 @@ export default class ParseObject {
     if (clone.set) {
       clone.set(attributes);
     }
+    return clone;
+  }
+
+  /**
+   * Creates a new instance of this object. Not to be confused with clone()
+   * @method newInstance
+   * @return {Parse.Object}
+   */
+  newInstance(): any {
+    let clone = new this.constructor();
+    if (!clone.className) {
+      clone.className = this.className;
+    }
+    clone.id = this.id;
+    if (singleInstance) {
+      // Just return an object with the right id
+      return clone;
+    }
+
+    let stateController = CoreManager.getObjectStateController();
+    stateController.duplicateState(this._getStateIdentifier(), clone._getStateIdentifier());
     return clone;
   }
 

--- a/src/UniqueInstanceStateController.js
+++ b/src/UniqueInstanceStateController.js
@@ -123,6 +123,23 @@ export function enqueueTask(obj: ParseObject, task: () => ParsePromise): ParsePr
   return state.tasks.enqueue(task);
 }
 
+export function duplicateState(source: ParseObject, dest: ParseObject): void {
+  let oldState = initializeState(source);
+  let newState = initializeState(dest);
+  for (let key in oldState.serverData) {
+    newState.serverData[key] = oldState.serverData[key];
+  }
+  for (let index = 0; index < oldState.pendingOps.length; index++) {
+    for (let key in oldState.pendingOps[index]) {
+      newState.pendingOps[index][key] = oldState.pendingOps[index][key];
+    }
+  }
+  for (let key in oldState.objectCache) {
+    newState.objectCache[key] = oldState.objectCache[key];
+  }
+  newState.existed = oldState.existed;
+}
+
 export function clearAllState() {
   objectState = new WeakMap();
 }

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1720,6 +1720,20 @@ describe('ObjectController', () => {
 
     xhrs[0].onreadystatechange();
   });
+
+  it('can create a new instance of an object', () => {
+    let o = ParseObject.fromJSON({
+      className: 'Clone',
+      objectId: 'C12',
+    });
+    let o2 = o.newInstance();
+    expect(o.id).toBe(o2.id);
+    expect(o.className).toBe(o2.className);
+    o.set({ valid: true });
+    expect(o2.get('valid')).toBe(true);
+
+    expect(o).not.toBe(o2);
+  });
 });
 
 describe('ParseObject (unique instance mode)', () => {
@@ -1901,6 +1915,21 @@ describe('ParseObject (unique instance mode)', () => {
     o2.set({ name: 'foo' });
     expect(o.has('name')).toBe(false);
     expect(o2.has('name')).toBe(true);
+  });
+
+  it('can create a new instance of an object', () => {
+    let o = ParseObject.fromJSON({
+      className: 'Clone',
+      objectId: 'C14',
+    });
+    let o2 = o.newInstance();
+    expect(o.id).toBe(o2.id);
+    expect(o.className).toBe(o2.className);
+    expect(o).not.toBe(o2);
+    o.set({ valid: true });
+    expect(o2.get('valid')).toBe(undefined);
+    o2 = o.newInstance();
+    expect(o2.get('valid')).toBe(true);
   });
 });
 

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -100,6 +100,28 @@ describe('ParseUser', () => {
     expect(clone.get('sessionToken')).toBe(undefined);
   });
 
+  it('can create a new instance of a User', () => {
+    ParseObject.disableSingleInstance();
+    let o = ParseObject.fromJSON({
+      className: '_User',
+      objectId: 'U111',
+      username: 'u111',
+      email: 'u111@parse.com',
+      sesionToken: '1313'
+    });
+    let o2 = o.newInstance();
+    expect(o.id).toBe(o2.id);
+    expect(o.className).toBe(o2.className);
+    expect(o.get('username')).toBe(o2.get('username'));
+    expect(o.get('sessionToken')).toBe(o2.get('sessionToken'));
+    expect(o).not.toBe(o2);
+    o.set({ admin: true });
+    expect(o2.get('admin')).toBe(undefined);
+    o2 = o.newInstance();
+    expect(o2.get('admin')).toBe(true);
+    ParseObject.enableSingleInstance();
+  });
+
   it('makes session tokens readonly', () => {
     var u = new ParseUser();
     expect(u.set.bind(u, 'sessionToken', 'token')).toThrow(


### PR DESCRIPTION
`ParseObject.prototype.newInstance()` creates a new, memory-unique instance of a Parse Object, as though it had been fetched again from the server. This is only really relevant in Unique Instance mode.