### PR TITLE
Fix 'events' resolution issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,7 @@ gulp.task('compile', function() {
 
 gulp.task('browserify', function() {
   var stream = browserify({
-    builtins: { _process: true },
+    builtins: ['_process', 'events'],
     entries: 'lib/browser/Parse.js',
     standalone: 'Parse'
   })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.20",
-    "events": "^1.1.0",
     "ws": "^1.0.1",
     "xmlhttprequest": "^1.7.0"
   },

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * This is a simple wrapper to unify EventEmitter implementations across platforms.
+ */
+
+if (process.env.PARSE_BUILD === 'react-native') {
+  module.exports = require('EventEmitter');
+} else {
+  module.exports = require('events').EventEmitter;
+}

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -8,7 +8,7 @@
  *
  */
 
-import events from 'events';
+import EventEmitter from './EventEmitter';
 import ParsePromise from './ParsePromise';
 import ParseObject from './ParseObject';
 import LiveQuerySubscription from './LiveQuerySubscription';
@@ -122,7 +122,7 @@ let generateInterval = (k) => {
  * 
  * 
  */
-export default class LiveQueryClient extends events.EventEmitter {
+export default class LiveQueryClient extends EventEmitter {
   attempts: number;
   id: number;
   requestId: number;

--- a/src/LiveQuerySubscription.js
+++ b/src/LiveQuerySubscription.js
@@ -8,7 +8,7 @@
  *
  */
 
-import events from 'events';
+import EventEmitter from './EventEmitter';
 import CoreManager from './CoreManager';
 
 /**
@@ -90,7 +90,7 @@ import CoreManager from './CoreManager';
  *
  * 
  */
-export default class Subscription extends events.EventEmitter {
+export default class Subscription extends EventEmitter {
   constructor(id, query, sessionToken) {
     super();
     this.id = id;

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -1,4 +1,4 @@
-import events from 'events';
+import EventEmitter from './EventEmitter';
 import LiveQueryClient from './LiveQueryClient';
 import CoreManager from './CoreManager';
 
@@ -41,7 +41,7 @@ function close() {
  * @static
  * 
  */
-let LiveQuery = new events.EventEmitter();
+let LiveQuery = new EventEmitter();
 
 /**
  * After open is called, the LiveQuery will try to send a connect request

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -15,6 +15,7 @@ jest.dontMock('../decode');
 jest.dontMock('../encode');
 jest.dontMock('../equals');
 jest.dontMock('../escape');
+jest.dontMock('../EventEmitter');
 jest.dontMock('../ObjectStateMutations');
 jest.dontMock('../parseDate');
 jest.dontMock('../ParseError');


### PR DESCRIPTION
This should make sure that EventEmitter is properly initialized on every platform and build. The code for parse-latest looks correct, as do the `lib` builds, but please test this thoroughly.