### PR TITLE
Adds Hooks API on parse/node

### DIFF
--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -108,6 +108,13 @@ type UserController = {
   upgradeToRevocableSession: (user: ParseUser, options: RequestOptions) => ParsePromise;
   linkWith: (user: ParseUser, authData: AuthData) => ParsePromise;
 };
+type HooksController = {
+  get: (type: string, functionName?: string, triggerName?: string) => ParsePromise;
+  create: (hook: mixed) => ParsePromise;
+  delete: (hook: mixed) => ParsePromise;
+  update: (hook: mixed) => ParsePromise;
+  send: (method: string, path: string, body?: mixed) => ParsePromise;
+}
 
 var config: { [key: string]: mixed } = {
   // Defaults
@@ -476,5 +483,20 @@ module.exports = {
 
   getLiveQueryController(): any {
     return config['LiveQueryController'];
+  },
+
+  setHooksController(controller: HooksController) {
+    ['create', 'get', 'update', 'remove'].forEach((func) => {
+      if (typeof controller[func] !== 'function') {
+        throw new Error(
+          `A HooksController must implement ${func}()`
+        );
+      }
+    })
+    config['HooksController'] = controller;
+  },
+
+  getHooksController(): HooksController {
+    return config['HooksController'];
   }
 }

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -147,6 +147,7 @@ if (process.env.PARSE_BUILD === 'node') {
   Parse.Cloud.useMasterKey = function() {
     CoreManager.set('USE_MASTER_KEY', true);
   }
+  Parse.Hooks = require('./ParseHooks');
 }
 
 // For legacy requires, of the form `var Parse = require('parse').Parse`

--- a/src/ParseHooks.js
+++ b/src/ParseHooks.js
@@ -1,0 +1,130 @@
+import CoreManager from './CoreManager';
+import decode from './decode';
+import encode from './encode';
+import ParseError from './ParseError';
+import ParsePromise from './ParsePromise';
+
+export function getFunctions() {
+  return CoreManager.getHooksController().get("functions");
+}
+
+export function  getTriggers() {
+  return CoreManager.getHooksController().get("triggers");
+}
+
+export function getFunction(name) {
+  return CoreManager.getHooksController().get("functions", name);
+}
+
+export function getTrigger(className, triggerName) {
+  return CoreManager.getHooksController().get("triggers", className, triggerName);
+}
+
+export function createFunction(functionName, url) {
+  return create({functionName: functionName, url: url});
+}
+
+export function createTrigger(className, triggerName, url) {
+  return create({className: className, triggerName: triggerName, url: url});
+}
+
+export function create(hook) {
+  return CoreManager.getHooksController().create(hook);
+}
+
+export function updateFunction(functionName, url) {
+  return update({functionName: functionName, url: url});
+}
+
+export function updateTrigger(className, triggerName, url) {
+  return update({className: className, triggerName: triggerName, url: url});
+}
+
+export function update(hook) {
+  return CoreManager.getHooksController().update(hook);
+}
+
+export function removeFunction(functionName) {
+  return remove({functionName: functionName});
+}
+
+export function removeTrigger(className, triggerName) {
+  return remove({className: className, triggerName: triggerName});
+}
+
+export function remove(hook) {
+  return CoreManager.getHooksController().remove(hook);
+}
+
+var DefaultController = {
+
+  get(type, functionName, triggerName) {
+    var url = "/hooks/"+type;
+    if(functionName) {
+      url += "/"+functionName;
+      if (triggerName) {
+        url += "/"+triggerName;
+      }
+    }
+    return this.sendRequest("GET", url);
+  },
+
+  create(hook) {
+    var url;
+    if (hook.functionName && hook.url) {
+        url = "/hooks/functions";
+    } else if (hook.className && hook.triggerName && hook.url) {
+        url = "/hooks/triggers";
+    } else {
+      return Promise.reject({error: 'invalid hook declaration', code: 143});
+    }
+    return this.sendRequest("POST", url, hook);
+  },
+
+  remove(hook) {
+    var url;
+    if (hook.functionName) {
+        url = "/hooks/functions/"+hook.functionName;
+        delete hook.functionName;
+    } else if (hook.className && hook.triggerName) {
+        url = "/hooks/triggers/"+hook.className+"/"+hook.triggerName;
+        delete hook.className;
+        delete hook.triggerName;
+    } else {
+      return Promise.reject({error: 'invalid hook declaration', code: 143});
+    }
+    return this.sendRequest("PUT", url, { "__op": "Delete" });
+  },
+
+  update(hook) {
+    var url;
+    if (hook.functionName && hook.url) {
+        url = "/hooks/functions/"+hook.functionName;
+        delete hook.functionName;
+    } else if (hook.className && hook.triggerName && hook.url) {
+        url = "/hooks/triggers/"+hook.className+"/"+hook.triggerName;
+        delete hook.className;
+        delete hook.triggerName;
+    } else {
+      return Promise.reject({error: 'invalid hook declaration', code: 143});
+    }
+    return this.sendRequest('PUT', url, hook);
+  },
+
+  sendRequest(method, url, body) {
+    return CoreManager.getRESTController().request(method, url, body, {useMasterKey: true}).then((res) => {
+      var decoded = decode(res);
+      if (decoded) {
+        return ParsePromise.as(decoded);
+      }
+      return ParsePromise.error(
+        new ParseError(
+          ParseError.INVALID_JSON,
+          'The server returned an invalid response.'
+        )
+      );
+    })
+  }
+};
+
+CoreManager.setHooksController(DefaultController);

--- a/src/__tests__/Hooks-test.js
+++ b/src/__tests__/Hooks-test.js
@@ -1,0 +1,198 @@
+/**
+* Copyright (c) 2015-present, Parse, LLC.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*/
+
+jest.dontMock('../ParseHooks');
+jest.dontMock('../CoreManager');
+jest.dontMock('../decode');
+jest.dontMock('../encode');
+jest.dontMock('../ParsePromise');
+
+var Hooks = require('../ParseHooks');
+var CoreManager = require('../CoreManager');
+var ParsePromise = require('../ParsePromise');
+
+var defaultController = CoreManager.getHooksController();
+
+describe('Hooks', () => {
+  beforeEach(() => {
+    var run = jest.genMockFunction();
+    run.mockReturnValue(ParsePromise.as({
+      result: {}
+    }));
+    defaultController.sendRequest = run;
+    CoreManager.setHooksController(defaultController);
+  });
+
+  it('shoud properly build GET functions', () => {
+    Hooks.getFunctions();
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['GET', '/hooks/functions']);
+  });
+
+  it('shoud properly build GET triggers', () => {
+    Hooks.getTriggers();
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['GET', '/hooks/triggers']);
+  })
+
+  it('shoud properly build GET function', () => {
+    Hooks.getFunction('functionName');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['GET', '/hooks/functions/functionName']);
+  })
+
+  it('shoud properly build GET trigger', () => {
+    Hooks.getTrigger('MyClass', 'beforeSave');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['GET', '/hooks/triggers/MyClass/beforeSave']);
+  })
+
+  it('shoud properly build POST function', () => {
+    Hooks.createFunction('myFunction', 'https://dummy.com');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['POST', '/hooks/functions', {
+      functionName: 'myFunction',
+      url: 'https://dummy.com'
+    }]);
+  })
+
+  it('shoud properly build POST trigger', () => {
+    Hooks.createTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['POST', '/hooks/triggers', {
+      className: 'MyClass',
+      triggerName: 'beforeSave',
+      url: 'https://dummy.com'
+    }]);
+  })
+
+  it('shoud properly build PUT function', () => {
+    Hooks.updateFunction('myFunction', 'https://dummy.com');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['PUT', '/hooks/functions/myFunction', {
+      url: 'https://dummy.com'
+    }]);
+  })
+
+  it('shoud properly build PUT trigger', () => {
+    Hooks.updateTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['PUT', '/hooks/triggers/MyClass/beforeSave', {
+      url: 'https://dummy.com'
+    }]);
+  })
+
+
+  it('shoud properly build removeFunction', () => {
+    Hooks.removeFunction('myFunction');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['PUT', '/hooks/functions/myFunction', { "__op": "Delete" }]);
+  })
+
+  it('shoud properly build removeTrigger', () => {
+    Hooks.removeTrigger('MyClass', 'beforeSave');
+
+    expect(CoreManager.getHooksController().sendRequest.mock.calls[0])
+    .toEqual(['PUT', '/hooks/triggers/MyClass/beforeSave', { "__op": "Delete" }]);
+  })
+
+  it('shoud throw invalid create', () => {
+    Hooks.create({functionName: 'myFunction'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.create({url: 'http://dummy.com'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.create({className: 'MyClass'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.create({className: 'MyClass', url: 'http://dummy.com'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.create({className: 'MyClass', triggerName: 'beforeSave'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+  })
+
+  it('shoud throw invalid update', () => {
+    Hooks.update({functionssName: 'myFunction'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.update({className: 'MyClass'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.update({className: 'MyClass', url: 'http://dummy.com'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+  })
+
+  it('shoud throw invalid remove', () => {
+    Hooks.remove({functionssName: 'myFunction'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.remove({className: 'MyClass'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+
+    Hooks.remove({className: 'MyClass', url: 'http://dummy.com'}).then(() => {
+      fail('should not succeed')
+    }).catch((err) => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
+  })
+
+
+});


### PR DESCRIPTION
- Adds hooks API to parse/node in perspective to remove the hooks API from experimental on parse-server
- Will remove Parse.Hooks from parse-server once merged
- Will keep E2E tests in parse-server to make sure the API is compliant
- Tested on parse.com and create/update/remove works perfectly without any changes