### PR TITLE
Fixes Websocket Implementation for Safari

### DIFF
--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -324,7 +324,7 @@ export default class LiveQueryClient extends EventEmitter {
     if (process.env.PARSE_BUILD === 'node') {
       return require('ws');
     } else if (process.env.PARSE_BUILD === 'browser') {
-      return typeof WebSocket === 'function' ? WebSocket : null;
+      return typeof WebSocket === 'function' || typeof WebSocket === 'object' ? WebSocket : null;
     } else if (process.env.PARSE_BUILD === 'react-native') {
       return WebSocket;
     }


### PR DESCRIPTION
In Safari, the WebSocket is typeof Object. This fix enables proper LiveQuery support for some versions of Safari (it appears that Safari Technology Preview handles Websockets a little differently, so this may not be an issue in future versions of Safari). 