### PR TITLE
Automatically export the right the required SDK for a given platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // Export the correct version of the SDK for each platform that requires 'parse'
 if (typeof window === 'undefined') {
   module.exports = require('./lib/node/Parse.js');
-} else if (navigator && navigator.product === 'ReactNative') {
+} else if (typeof navigator === 'object' && navigator.product === 'ReactNative') {
   module.exports = require('./lib/react-native/Parse.js');
 } else {
   module.exports = require('./lib/browser/Parse.js');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,8 @@
-module.exports = require('./lib/browser/Parse.js');
+// Export the correct version of the SDK for each platform that requires 'parse'
+if (typeof window === 'undefined') {
+  module.exports = require('./lib/node/Parse.js');
+} else if (navigator && navigator.product === 'ReactNative') {
+  module.exports = require('./lib/react-native/Parse.js');
+} else {
+  module.exports = require('./lib/browser/Parse.js');
+}


### PR DESCRIPTION
This would resolve #269 and allow us to remove the `parse-shim` module from our codebase.

I assume we are not alone in using the JS SDK on all three platforms (Browser, Node, React-Native) and it has become harder to make it work seamlessly on all three as packages like parse-server and parse-cloud-express modify the exported parse module (overwriting Parse.Cloud members for example). So we'd like to make it official instead of using a shim.

Additionally, it's also more Parse-like to 'just work' as a JS sdk instead of having another set of instructions: "require x when you are on platform y, but z when you are on platform whatever"