### PR TITLE
Fix LiveQuery SSL

### DIFF
--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -104,13 +104,13 @@ let DefaultLiveQueryController = {
       
       // If we can not find Parse.liveQueryServerURL, we try to extract it from Parse.serverURL
       if (!liveQueryServerURL) {
-        var tempServerURL = CoreManager.get('SERVER_URL');
-        var protocol = 'ws://';
+        const tempServerURL = CoreManager.get('SERVER_URL');
+        let protocol = 'ws://';
         // If Parse is being served over SSL/HTTPS, ensure LiveQuery Server uses 'wss://' prefix
         if (tempServerURL.indexOf('https') === 0) {
           protocol = 'wss://'
         }
-        var host = tempServerURL.replace(/^https?:\/\//, '');
+        const host = tempServerURL.replace(/^https?:\/\//, '');
         liveQueryServerURL = protocol + host;
         CoreManager.set('LIVEQUERY_SERVER_URL', liveQueryServerURL);
       }

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -101,11 +101,17 @@ let DefaultLiveQueryController = {
       if (liveQueryServerURL && liveQueryServerURL.indexOf('ws') !== 0) {
         throw new Error('You need to set a proper Parse LiveQuery server url before using LiveQueryClient');
       }
-
+      
       // If we can not find Parse.liveQueryServerURL, we try to extract it from Parse.serverURL
       if (!liveQueryServerURL) {
-        let host = CoreManager.get('SERVER_URL').replace(/^https?:\/\//, '');
-        liveQueryServerURL = 'ws://' + host;
+        var tempServerURL = CoreManager.get('SERVER_URL');
+        var protocol = 'ws://';
+        // If Parse is being served over SSL/HTTPS, ensure LiveQuery Server uses 'wss://' prefix
+        if (tempServerURL.indexOf('https') === 0) {
+          protocol = 'wss://'
+        }
+        var host = tempServerURL.replace(/^https?:\/\//, '');
+        liveQueryServerURL = protocol + host;
         CoreManager.set('LIVEQUERY_SERVER_URL', liveQueryServerURL);
       }
 


### PR DESCRIPTION
This allows LiveQueryServer to work over Parse Sever with SSL