### PR TITLE
Update documentation for Each queries.

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -395,9 +395,15 @@ export default class ParseQuery {
    * @method each
    * @param {Function} callback Callback that will be called with each result
    *     of the query.
-   * @param {Object} options An optional Backbone-like options object with
-   *     success and error callbacks that will be invoked once the iteration
-   *     has finished.
+   * @param {Object} options A Backbone-style options object. Valid options
+   * are:<ul>
+   *   <li>success: Function to call when the iteration completes successfully.
+   *   <li>error: Function to call when the iteration fails.
+   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+   *     be used for this request.
+   *   <li>sessionToken: A valid session token, used for making a request on
+   *       behalf of a specific user.
+   * </ul>
    * @return {Parse.Promise} A promise that will be fulfilled once the
    *     iteration has completed.
    */


### PR DESCRIPTION
Hi, it appears Each queries can also accept useMasterKey and sessionToken option but it wasn't documented, this PR is just a minor docs fix.