### PR TITLE
Adds ability to interpolate delete operations

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -375,6 +375,9 @@ export default class ParseObject {
         changes[attr] = new ParseACL(response[attr]);
       } else if (attr !== 'objectId') {
         changes[attr] = decode(response[attr]);
+        if (changes[attr] instanceof UnsetOp) {
+          changes[attr] = undefined;
+        }
       }
     }
     if (changes.createdAt && !changes.updatedAt) {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -852,6 +852,25 @@ describe('ParseObject', () => {
       done();
     });
   }));
+  
+  it('interpolates delete operations', asyncHelper((done) => {
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: { objectId: 'newattributes', deletedKey: {__op: 'Delete'} }
+      }])
+    );
+    var o = new ParseObject('Item');
+    o.save({ key: 'value', deletedKey: 'keyToDelete' }).then(() => {
+      expect(o.get('key')).toBe('value');
+      expect(o.get('deletedKey')).toBeUndefined();
+      o = new ParseObject('Item');
+      return o.save({ ACL: 'not an acl' });
+    }).then(null, (error) => {
+      expect(error.code).toBe(-1);
+      done();
+    });
+  }));
 
   it('can make changes while in the process of a save', asyncHelper((done) => {
     var xhr = {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -864,10 +864,6 @@ describe('ParseObject', () => {
     o.save({ key: 'value', deletedKey: 'keyToDelete' }).then(() => {
       expect(o.get('key')).toBe('value');
       expect(o.get('deletedKey')).toBeUndefined();
-      o = new ParseObject('Item');
-      return o.save({ ACL: 'not an acl' });
-    }).then(null, (error) => {
-      expect(error.code).toBe(-1);
       done();
     });
   }));


### PR DESCRIPTION
On parse.com, when running a beforeSave hook, if a key is `unset` the change is not propagated to the client. 

On parse-server, we forward this change by setting the `key: {__op: Delete}` that is interpolated by the JS SDK as an UnsetOp.

This proposed PR will set key = undefined in those cases fixing https://github.com/ParsePlatform/parse-server/issues/1840

https://github.com/ParsePlatform/parse-server/pull/1946