### PR TITLE
Update ParseFile.js

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -24,7 +24,7 @@ export type FileSource = {
 };
 
 var dataUriRegexp =
-  /^data:([a-zA-Z]*\/[a-zA-Z+.-]*);(charset=[a-zA-Z0-9\-\/\s]*,)?base64,(\S+)/;
+  /^data:([a-zA-Z]*\/[a-zA-Z+.-]*);(charset=[a-zA-Z0-9\-\/\s]*,)?base64,/;
 
 function b64Digit(number: number): string {
   if (number < 26) {
@@ -99,15 +99,10 @@ export default class ParseFile {
         type: specifiedType
       };
     } else if (data && data.hasOwnProperty('base64')) {
-  		var commaIndex = data.base64.indexOf(',');
-  		try {
-  		    window.atob(commaIndex === -1?data.base64:data.base64.slice(commaIndex + 1));
-  		} catch(e) {
-  		    throw new TypeError('Cannot create a Parse.File with that data.');
-  		}
+      var commaIndex = data.base64.indexOf(',');
   
       if (commaIndex !== -1) {
-        var matches = dataUriRegexp.exec(data.base64.slice(0, 100));
+        var matches = dataUriRegexp.exec(data.base64.slice(0, commaIndex + 1));
         // if data URI with type and charset, there will be 4 matches.
         this._source = {
           format: 'base64',

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -102,13 +102,12 @@ export default class ParseFile {
   		var commaIndex = data.base64.indexOf(',');
   		try {
   		    window.atob(commaIndex === -1?data.base64:data.base64.slice(commaIndex + 1));
-  		    return true;
   		} catch(e) {
   		    throw new TypeError('Cannot create a Parse.File with that data.');
   		}
   
       if (commaIndex !== -1) {
-        var matches = dataUriRegexp.slice(100).exec(data.base64);
+        var matches = dataUriRegexp.exec(data.base64.slice(0, 100));
         // if data URI with type and charset, there will be 4 matches.
         this._source = {
           format: 'base64',

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -99,12 +99,20 @@ export default class ParseFile {
         type: specifiedType
       };
     } else if (data && data.hasOwnProperty('base64')) {
-      var matches = dataUriRegexp.exec(data.base64);
-      if (matches && matches.length > 0) {
+  		var commaIndex = data.base64.indexOf(',');
+  		try {
+  		    window.atob(commaIndex === -1?data.base64:data.base64.slice(commaIndex + 1));
+  		    return true;
+  		} catch(e) {
+  		    throw new TypeError('Cannot create a Parse.File with that data.');
+  		}
+  
+      if (commaIndex !== -1) {
+        var matches = dataUriRegexp.slice(100).exec(data.base64);
         // if data URI with type and charset, there will be 4 matches.
         this._source = {
           format: 'base64',
-          base64: matches.length === 4 ? matches[3] : matches[2],
+          base64: data.base64.slice(commaIndex + 1),
           type: matches[1]
         };
       } else {


### PR DESCRIPTION
Fixed bug when base64 string is too long

RangeError: Maximum call stack size exceeded
    at RegExp.exec (native)
    at new e (http://localhost:2052/scripts/parse-1.6.14.min.js:13:25178)