### PR TITLE
closed #311: Parse.File sends incorrect Content-Type to API

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -245,7 +245,8 @@ var DefaultController = {
     // To directly upload a File, we use a REST-style AJAX request
     var headers = {
       'X-Parse-Application-ID': CoreManager.get('APPLICATION_ID'),
-      'X-Parse-JavaScript-Key': CoreManager.get('JAVASCRIPT_KEY')
+      'X-Parse-JavaScript-Key': CoreManager.get('JAVASCRIPT_KEY'),
+      'Content-Type': source.type || (source.file? source.file.type : null)
     };
     var url = CoreManager.get('SERVER_URL');
     if (url[url.length - 1] !== '/') {

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -125,7 +125,9 @@ const RESTController = {
       };
 
       headers = headers || {};
-      headers['Content-Type'] = 'text/plain'; // Avoid pre-flight
+      if (typeof(headers['Content-Type']) !== 'string') {
+        headers['Content-Type'] = 'text/plain'; // Avoid pre-flight
+      }
       if (CoreManager.get('IS_NODE')) {
         headers['User-Agent'] = 'Parse/' + CoreManager.get('VERSION') +
           ' (NodeJS ' + process.versions.node + ')';


### PR DESCRIPTION
See issue #311 for details and discussion.
Maybe test coverage should be improved for this functionality.
